### PR TITLE
Fix `refreshSession`

### DIFF
--- a/core/src/main/java/bsky4j/api/entity/atproto/server/ServerRefreshSessionResponse.java
+++ b/core/src/main/java/bsky4j/api/entity/atproto/server/ServerRefreshSessionResponse.java
@@ -2,8 +2,26 @@ package bsky4j.api.entity.atproto.server;
 
 public class ServerRefreshSessionResponse {
 
+    private String accessJwt;
+    private String refreshJwt;
     private String handle;
     private String did;
+
+    public String getAccessJwt() {
+        return accessJwt;
+    }
+
+    public void setAccessJwt(String accessJwt) {
+        this.accessJwt = accessJwt;
+    }
+
+    public String getRefreshJwt() {
+        return refreshJwt;
+    }
+
+    public void setRefreshJwt(String refreshJwt) {
+        this.refreshJwt = refreshJwt;
+    }
 
     public String getHandle() {
         return handle;

--- a/core/src/main/java/bsky4j/api/entity/share/RefreshAuthRequest.java
+++ b/core/src/main/java/bsky4j/api/entity/share/RefreshAuthRequest.java
@@ -1,0 +1,8 @@
+package bsky4j.api.entity.share;
+
+public class RefreshAuthRequest extends AuthRequest {
+
+    public RefreshAuthRequest(String accessJwt) {
+        super(accessJwt);
+    }
+}

--- a/core/src/main/java/bsky4j/internal/atproto/_ServerResource.java
+++ b/core/src/main/java/bsky4j/internal/atproto/_ServerResource.java
@@ -1,5 +1,11 @@
 package bsky4j.internal.atproto;
 
+import static bsky4j.internal.share._InternalUtility.proceed;
+import static bsky4j.internal.share._InternalUtility.xrpc;
+
+import net.socialhub.http.HttpMediaType;
+import net.socialhub.http.HttpRequestBuilder;
+
 import bsky4j.ATProtocolTypes;
 import bsky4j.api.atproto.ServerResource;
 import bsky4j.api.entity.atproto.server.ServerCreateSessionRequest;
@@ -8,11 +14,6 @@ import bsky4j.api.entity.atproto.server.ServerGetSessionResponse;
 import bsky4j.api.entity.atproto.server.ServerRefreshSessionResponse;
 import bsky4j.api.entity.share.AuthRequest;
 import bsky4j.api.entity.share.Response;
-import net.socialhub.http.HttpMediaType;
-import net.socialhub.http.HttpRequestBuilder;
-
-import static bsky4j.internal.share._InternalUtility.proceed;
-import static bsky4j.internal.share._InternalUtility.xrpc;
 
 public class _ServerResource implements ServerResource {
 
@@ -90,7 +91,7 @@ public class _ServerResource implements ServerResource {
                     .path(ATProtocolTypes.ServerRefreshSession)
                     .request(HttpMediaType.APPLICATION_JSON)
                     .header("Authorization", request.getBearerToken())
-                    .get();
+                    .post();
         });
     }
 


### PR DESCRIPTION
Fixed that it did not work when trying to refresh the session.

- Change method (`GET` to `POST`)
- Add `RefreshAuthRequest`
- Add some properties to `ServerRefreshSessionResponse`

----

初めて Bluesky の API を触ったので全然見当違いの修正をしていたら申し訳ないです。

割とすぐに accessJwt の有効期限が切れるので refreshJwt を使ってリフレッシュしようとしたら動作しなかったのでいくつか修正してみました。

例によってZonePaneで使わせていただいていて、実際には下記のコードで使っています(Kotlinで恐縮です)。
`BskyAccountProvider` はアプリ内のアカウント情報リポジトリです。

```kotlin
    fun <T> executeWithAutoRetry(accountIdWIN: AccountIdWIN, logger: MyLogger, request: (BlueskyClient) -> T): T {

        val bskyAccountProvider = BskyAccountProvider(logger)
        val client = bskyAccountProvider.getBlueskyClient(accountIdWIN)
            ?: throw BlueskyException(java.lang.Exception("Bluesky instance is not found"))

        return try {
            // まずは通常のトークンで実行する
            request.invoke(client)
        } catch (e: Exception) {
            // ExpiredToken の場合、ここで refresh して再度実行する
            logger.ee(e)
            if (e is ATProtocolException && e.error == "ExpiredToken") {
                val newJwt = client.bluesky.server().refreshSession(
                    RefreshAuthRequest(client.refreshJwt)
                ).get()

                // Refresh したトークンを保存する
                val updated = bskyAccountProvider.updateBlueskyAccessJwt(accountIdWIN, newJwt.accessJwt, newJwt.refreshJwt)

                request.invoke(BlueskyClient(client.bluesky, newJwt.accessJwt, newJwt.refreshJwt))
            } else {
                throw e
            }
        }
    }
```
